### PR TITLE
fix(workflows): add missing arg in sr

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: update github release
         run: |
-          gh release edit -R ${{ github.repository }} --title "⚙️ Poetry Import Plugin ${{ needs.semantic-release.outputs.new_release_tag }}"
+          gh release edit -R ${{ github.repository }} --title "⚙️ Poetry Import Plugin ${{ needs.semantic-release.outputs.new_release_tag }}" "${{ needs.semantic-release.outputs.new_release_tag }}"
         env:
           GH_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release.yml` file. The change updates the `gh release edit` command to include the new release tag as an additional argument.