### PR TITLE
fix(workflows): drop build too many times

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,5 +67,4 @@ jobs:
 
           # build the package and publish
           rm -rf dist
-          pipx run poetry build
           pipx run poetry publish --build --username __token__ --password ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release.yml` file. The change removes the redundant `pipx run poetry build` command to streamline the release process.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L70): Removed the `pipx run poetry build` command to avoid redundancy in the release workflow.